### PR TITLE
Info.plist に輸出コンプライアンス設定を追加

### DIFF
--- a/heyho_ios/Info.plist
+++ b/heyho_ios/Info.plist
@@ -20,6 +20,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## Summary
- `ITSAppUsesNonExemptEncryption` を `false` に設定し、App Store Connect アップロード時の輸出コンプライアンス質問を自動回答させる
- Firebase の標準暗号化（HTTPS/TLS）のみ使用のため exempt と判断

Closes #36

## Test plan
- [ ] Xcode でビルドし Info.plist が正しく反映されることを確認
- [ ] 次回 App Store Connect アップロード時に輸出コンプライアンス質問が自動回答されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)